### PR TITLE
Add CODECOV to Github Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,6 @@ jobs:
       env:
         DATABASE_URI: postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/postgres
     - name: Upload Coverage Reports to codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5.4.3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
       run: pytest --pspec --cov=service --cov-fail-under=95 --cov-report=xml
       env:
         DATABASE_URI: postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/postgres
-    - name: Upload Coverage Reports to codecov
-      uses: codecov/codecov-action@v5.4.3
+    - name: Install dependencies for Codecov to work
+      run: apt-get update && apt-get install -y git curl gpg
+    - name: Upload Coverage Reports to Codecov
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
         pipenv install --system --dev
     - name: Linting
       run: |
-        sudo apt-get install git
         flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistic
         pylint service tests --max-line-length=127

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,17 +34,21 @@ jobs:
       run: |
         python -m pip install --upgrade pip pipenv
         pipenv install --system --dev
+    
     - name: Linting
       run: |
         flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistic
         pylint service tests --max-line-length=127
+    
     - name: Run Unit Tests
       run: pytest --pspec --cov=service --cov-fail-under=95 --cov-report=xml
       env:
         DATABASE_URI: postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/postgres
+    
     - name: Install dependencies for Codecov to work
       run: apt-get update && apt-get install -y git curl gpg
+    
     - name: Upload Coverage Reports to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,7 @@ jobs:
       run: pytest --pspec --cov=service --cov-fail-under=95 --cov-report=xml
       env:
         DATABASE_URI: postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/postgres
+    - name: Upload Coverage Reports to codecov
+      uses: codecov/codecov-action@v4.6.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Shopcarts Microservice CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    container: python:3.11-slim
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: pgs3cr3t
+          POSTGRES_DB: shopcart
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip pipenv
+        pipenv install --system --dev
+    - name: Linting
+      run: |
+        flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistic
+        pylint service tests --max-line-length=127
+    - name: Run Unit Tests
+      run: pytest --pspec --cov=service --cov-fail-under=95 --cov-report=xml
+      env:
+        DATABASE_URI: postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,6 @@ jobs:
       env:
         DATABASE_URI: postgresql+psycopg://postgres:pgs3cr3t@postgres:5432/postgres
     - name: Upload Coverage Reports to codecov
-      uses: codecov/codecov-action@v4.6.0
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
made the following changes

- added CODECOV action v5
- referenced CODECOV_TOKEN from GitHub secrets to use in Actions
- Installed `git` `curl` and `gpg` as dependencies for CODECOV to run